### PR TITLE
Adding support for API key restrictions for iOS and Android

### DIFF
--- a/google/api/control/check_request.py
+++ b/google/api/control/check_request.py
@@ -231,8 +231,17 @@ class Info(collections.namedtuple('Info',
             raise ValueError('the operation name must be set')
         op = super(Info, self).as_operation(timer=timer)
         labels = {}
+        if self.android_cert_fingerprint:
+            labels[_KNOWN_LABELS.SCC_ANDROID_CERT_FINGERPRINT.label_name] = self.android_cert_fingerprint
+
+        if self.android_package_name:
+            labels[_KNOWN_LABELS.SCC_ANDROID_PACKAGE_NAME.label_name] = self.android_package_name
+
         if self.client_ip:
             labels[_KNOWN_LABELS.SCC_CALLER_IP.label_name] = self.client_ip
+
+        if self.ios_bundle_id:
+            labels[_KNOWN_LABELS.SCC_IOS_BUNDLE_ID.label_name] = self.ios_bundle_id
 
         if self.referer:
             labels[_KNOWN_LABELS.SCC_REFERER.label_name] = self.referer

--- a/google/api/control/label_descriptor.py
+++ b/google/api/control/label_descriptor.py
@@ -199,8 +199,14 @@ class KnownLabels(Enum):
     GCP_API_VERSION = (
         'serviceruntime.googleapis.com/api_version', ValueType.STRING, Kind.USER,
         set_api_version)
+    SCC_ANDROID_CERT_FINGERPRINT = (
+        'servicecontrol.googleapis.com/android_cert_fingerprint', ValueType.STRING, Kind.SYSTEM, None)
+    SCC_ANDROID_PACKAGE_NAME = (
+        'servicecontrol.googleapis.com/android_package_name', ValueType.STRING, Kind.SYSTEM, None)
     SCC_CALLER_IP = (
         'servicecontrol.googleapis.com/caller_ip', ValueType.STRING, Kind.SYSTEM, None)
+    SCC_IOS_BUNDLE_ID = (
+        'servicecontrol.googleapis.com/ios_bundle_id', ValueType.STRING, Kind.SYSTEM, None)
     SCC_PLATFORM = (
         'servicecontrol.googleapis.com/platform', ValueType.STRING, Kind.SYSTEM,
         set_platform)

--- a/google/api/control/operation.py
+++ b/google/api/control/operation.py
@@ -39,9 +39,12 @@ logger = logging.getLogger(__name__)
 class Info(
         collections.namedtuple(
             'Info', [
+                'android_cert_fingerprint',
+                'android_package_name',
                 'api_key',
                 'api_key_valid',
                 'consumer_project_id',
+                'ios_bundle_id',
                 'operation_id',
                 'operation_name',
                 'referer',
@@ -54,11 +57,18 @@ class Info(
     operations using this surface
 
     Attributes:
+        android_cert_fingerprint (string): the SHA-1 signing-certificate
+          fingerprint of the calling app, used when the provided api_key is
+          restricted to certain Android apps
+        android_package_name (string): the package name of the calling app,
+          used when the provided api_key is restricted to certain Android apps
         api_key (string): the api key
         api_key_valid (bool): it the request has a valid api key. By default
           it is true, it will only be set to false if the api key cannot
           be validated by the service controller
         consumer_project_id (string): the project id of the api consumer
+        ios_bundle_id (string): the bundle identifier of the calling app,
+          used when the provided api_key is restricted to certain iOS apps
         operation_id (string): identity of the operation, which must be unique
           within the scope of the service. Calls to report and check on the
           same operation should carry the same operation id
@@ -70,9 +80,12 @@ class Info(
     # pylint: disable=too-many-arguments
 
     def __new__(cls,
+                android_cert_fingerprint='',
+                android_package_name='',
                 api_key='',
                 api_key_valid=False,
                 consumer_project_id='',
+                ios_bundle_id = '',
                 operation_id='',
                 operation_name='',
                 referer='',
@@ -80,9 +93,12 @@ class Info(
         """Invokes the base constructor with default values."""
         return super(cls, Info).__new__(
             cls,
+            android_cert_fingerprint,
+            android_package_name,
             api_key,
             api_key_valid,
             consumer_project_id,
+            ios_bundle_id,
             operation_id,
             operation_name,
             referer,

--- a/google/api/control/wsgi.py
+++ b/google/api/control/wsgi.py
@@ -371,10 +371,13 @@ class Middleware(object):
             api_key_valid = True
 
         check_info = check_request.Info(
+            android_cert_fingerprint=environ.get('HTTP_X_ANDROID_CERT', ''),
+            android_package_name=environ.get('HTTP_X_ANDROID_PACKAGE', ''),
             api_key=api_key,
             api_key_valid=api_key_valid,
             client_ip=environ.get('REMOTE_ADDR', ''),
             consumer_project_id=self._project_id,  # TODO: switch this to producer_project_id
+            ios_bundle_id=environ.get('HTTP_X_IOS_BUNDLE_IDENTIFIER', ''),
             operation_id=operation_id,
             operation_name=method_info.selector,
             referer=environ.get('HTTP_REFERER', ''),

--- a/test/test_check_request.py
+++ b/test/test_check_request.py
@@ -380,8 +380,11 @@ _INFO_TESTS = [
          startTime=_START_OF_EPOCH,
          endTime=_START_OF_EPOCH)),
     (check_request.Info(
+        android_cert_fingerprint='an_android_cert_fingerprint',
+        android_package_name='an_android_package_name',
         api_key='an_api_key',
         api_key_valid=True,
+        ios_bundle_id='an_ios_bundle_id',
         operation_id='an_op_id',
         operation_name='an_op_name',
         referer='a_referer',
@@ -391,6 +394,9 @@ _INFO_TESTS = [
          consumerId='api_key:an_api_key',
          labels = encoding.PyValueToMessage(
              messages.Operation.LabelsValue, {
+                 'servicecontrol.googleapis.com/android_cert_fingerprint': 'an_android_cert_fingerprint',
+                 'servicecontrol.googleapis.com/android_package_name': 'an_android_package_name',
+                 'servicecontrol.googleapis.com/ios_bundle_id': 'an_ios_bundle_id',
                  'servicecontrol.googleapis.com/user_agent': _WANTED_USER_AGENT,
                  'servicecontrol.googleapis.com/referer': 'a_referer',
                  'servicecontrol.googleapis.com/service_agent':

--- a/test/test_label_descriptor.py
+++ b/test/test_label_descriptor.py
@@ -227,8 +227,20 @@ class GcpApiVersion(KnownLabelsBase, unittest2.TestCase):
     WANTED_LABEL_DICT = {SUBJECT.label_name: 'dummy_version'}
 
 
+class SccAndroidCertFingerprint(KnownLabelsBase, unittest2.TestCase):
+    SUBJECT = _KNOWN.SCC_ANDROID_CERT_FINGERPRINT
+
+
+class SccAndroidPackageName(KnownLabelsBase, unittest2.TestCase):
+    SUBJECT = _KNOWN.SCC_ANDROID_PACKAGE_NAME
+
+
 class SccCallerIp(KnownLabelsBase, unittest2.TestCase):
     SUBJECT = _KNOWN.SCC_CALLER_IP
+
+
+class SccIosBundleId(KnownLabelsBase, unittest2.TestCase):
+    SUBJECT = _KNOWN.SCC_IOS_BUNDLE_ID
 
 
 class SccPlatform(KnownLabelsBase, unittest2.TestCase):

--- a/test/test_operation.py
+++ b/test/test_operation.py
@@ -332,8 +332,11 @@ _INFO_TESTS = [
          startTime=_REALLY_EARLY,
          endTime=_REALLY_EARLY)),
     (operation.Info(
+        android_cert_fingerprint='an_android_cert_fingerprint',
+        android_package_name='an_android_package_name',
         api_key='an_api_key',
         api_key_valid=True,
+        ios_bundle_id='an_ios_bundle_id',
         operation_id='an_op_id',
         operation_name='an_op_name',
         referer='a_referer',


### PR DESCRIPTION
This pull request adds support for api key restrictions for iOS and Android, as reported here: https://github.com/cloudendpoints/endpoints-management-python/issues/27.

The changes were based on information provided via the following discussion: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!topic/google-cloud-endpoints/I-u3sAUU3Ts.

This code has been successfully deployed to a test GAE project, and the api calls are now accepted for api keys restricted to an iOS bundle identifier, and keys restricted to an Android package name and certificate fingerprint, provided the correct headers are sent in the request.

Thanks,
Ian