### PR TITLE
Fix debug logging format

### DIFF
--- a/endpoints_management/control/check_request.py
+++ b/endpoints_management/control/check_request.py
@@ -471,7 +471,7 @@ class Aggregator(object):
 
         signature = sign(check_request)
         with self._cache as cache:
-            logger.debug(u'checking the cache for %s\n%s', signature, cache)
+            logger.debug(u'checking the cache for %r\n%s', signature, cache)
             item = cache.get(signature)
             if item is None:
                 return None  # signal to caller to send req


### PR DESCRIPTION
## How to reproduce error

- Deploy sample api: https://github.com/GoogleCloudPlatform/python-docs-samples/tree/master/appengine/standard/endpoints-frameworks-v2/echo
  ref: https://cloud.google.com/endpoints/docs/frameworks/python/quickstart-frameworks-python
- Call API. It looks fine. but...
```
curl -H "Content-Type: application/json" -X POST -d '{"content":"hello world"}' https://[PROJECT-ID].appspot.com/_ah/api/echo/v1/echo
{
 "content": "hello world"
}
```
- Open Stackdriver logging. https://console.cloud.google.com/
![image](https://user-images.githubusercontent.com/5005996/26866096-9fa89fee-4b9a-11e7-904c-64b9cbe8e425.png)
```
UnicodeDecodeError: 'ascii' codec can't decode byte 0x98 in position 0: ordinal not in range(128)
Logged from file check_request.py, line 474
```

## Expected

![image](https://user-images.githubusercontent.com/5005996/26866291-7be7cce6-4b9b-11e7-8757-a8077c16e083.png)
```
checking the cache for '\xee\xc4_>YD\xdc\x10\xd0f\xd1\x89\xbcB\xc7L'
DequeOutTTLCache([], maxsize=200, currsize=0)
```
