### PR TITLE
More gracefully handle errors loading service config

### DIFF
--- a/endpoints_management/config/__init__.py
+++ b/endpoints_management/config/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import
+
+from .service_config import ServiceConfigException

--- a/endpoints_management/config/service_config.py
+++ b/endpoints_management/config/service_config.py
@@ -39,6 +39,10 @@ _SERVICE_NAME_ENV_KEY = u"ENDPOINTS_SERVICE_NAME"
 _SERVICE_VERSION_ENV_KEY = u"ENDPOINTS_SERVICE_VERSION"
 
 
+class ServiceConfigException(Exception):
+    pass
+
+
 def fetch_service_config(service_name=None, service_version=None):
     """Fetches the service config from Google Serivce Management API.
 
@@ -76,7 +80,7 @@ def fetch_service_config(service_name=None, service_version=None):
     status_code = response.status
     if status_code != 200:
         message_template = u"Fetching service config failed (status code {})"
-        _log_and_raise(Exception, message_template.format(status_code))
+        _log_and_raise(ServiceConfigException, message_template.format(status_code))
 
     logger.debug(u'obtained service json from the management api:\n%s', response.data)
     service = encoding.JsonToMessage(messages.Service, response.data)

--- a/endpoints_management/control/service.py
+++ b/endpoints_management/control/service.py
@@ -37,8 +37,8 @@ import urllib
 from apitools.base.py import encoding
 from enum import Enum
 
+from ..config import service_config
 from . import label_descriptor, metric_descriptor, path_regex, sm_messages
-from endpoints_management.config import service_config
 
 
 logger = logging.getLogger(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pyjwkest>=1.0.0,<=1.0.9
 requests>=2.10.0,<3.0
 strict-rfc3339>=0.7,<0.8
 urllib3>=1.16,<2.0
+webob>=1.7.4

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ install_requires = [
     "requests>=2.10.0,<3.0",
     'strict-rfc3339>=0.7,<0.8',
     'urllib3>=1.16,<2.0',
+    'webob>=1.7.4',
 ]
 
 tests_require = [

--- a/test/test_service_config.py
+++ b/test/test_service_config.py
@@ -88,7 +88,7 @@ class ServiceConfigFetchTest(unittest.TestCase):
         mock_http_client = mock.MagicMock()
         mock_http_client.request.return_value = mock_response
         ServiceConfigFetchTest._get_http_client.return_value = mock_http_client
-        with self.assertRaisesRegexp(Exception, u"status code 403"):
+        with self.assertRaisesRegexp(service_config.ServiceConfigException, u"status code 403"):
             service_config.fetch_service_config()
 
     @mock.patch(u"endpoints_management.config.service_config.client.GoogleCredentials",

--- a/test/test_wsgi.py
+++ b/test/test_wsgi.py
@@ -134,11 +134,11 @@ class TestMiddleware(unittest2.TestCase):
 
     def test_load_service_failed(self):
         loader = mock.MagicMock(load=lambda: None)
-        with self.assertRaisesRegex(ValueError, u"Failed to load service config"):
-            wsgi.add_all(_DummyWsgiApp(),
-                         self.PROJECT_ID,
-                         mock.MagicMock(spec=client.Client),
-                         loader=loader)
+        result = wsgi.add_all(_DummyWsgiApp(),
+                              self.PROJECT_ID,
+                              mock.MagicMock(spec=client.Client),
+                              loader=loader)
+        assert result is wsgi.HTTPServiceUnavailable
 
 
 _SYSTEM_PARAMETER_CONFIG_TEST = b"""


### PR DESCRIPTION
If we can't load service config, we'll loudly log it and then replace the application with one which responds to all requests with HTTP 503 Service Unavailable.

Equivalent of https://github.com/cloudendpoints/endpoints-management-java/pull/39

This adds a dependency on webob rather than reinventing the "http exception" scheme. Google's webapp2 framework has a dependency on webob for the same reason. (An alternative implementation of this scheme is available from the werkzeug library.)