### PR TITLE
Bump cachetools dependency version.

### DIFF
--- a/endpoints_management/__init__.py
+++ b/endpoints_management/__init__.py
@@ -18,7 +18,7 @@ import logging
 
 from . import auth, config, control, gen
 
-__version__ = '1.11.0'
+__version__ = '1.11.1'
 
 _logger = logging.getLogger(__name__)
 _logger.setLevel(logging.INFO)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 backoff>=1.6.0
-cachetools>=1.0.0,<2
+cachetools>=1.0.0,<=2
 dogpile.cache>=0.6.1,<0.7
 enum34>=1.1.6,<2
 google-apitools>=0.5.21,<0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 backoff>=1.6.0
-cachetools>=1.0.0,<=2
+cachetools>=1.0.0,<3
 dogpile.cache>=0.6.1,<0.7
 enum34>=1.1.6,<2
 google-apitools>=0.5.21,<0.6

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open('endpoints_management/__init__.py', 'r') as f:
 
 install_requires = [
     'backoff>=1.6.0',
-    'cachetools>=1.0.0,<2',
+    'cachetools>=1.0.0,<=2',
     "dogpile.cache>=0.6.1,<0.7",
     'enum34>=1.1.6,<2',
     'google-apitools>=0.5.21,<0.6',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ with open('endpoints_management/__init__.py', 'r') as f:
 
 install_requires = [
     'backoff>=1.6.0',
-    'cachetools>=1.0.0,<=2',
+    'cachetools>=1.0.0,<3',
     "dogpile.cache>=0.6.1,<0.7",
     'enum34>=1.1.6,<2',
     'google-apitools>=0.5.21,<0.6',


### PR DESCRIPTION
I analysed the changes between cachetools v1.1.6 and v2.1.0. There
are no significant changes to the part of the library, which is
referenced by endpoints-management-python library.

I guess the version pin was placed for cachetools because the requirement was added in Jul 2016, three months before the relase of cachetools 2.0.0. It could have been intended as a safeguard against braking changes, unknown at that time.

We can safely release a new minor version 1.11.1 of google-endpoints-api-management with requirements on cachetools relaxed. I tested the change by locally building the modified google-endpoints-api-management package and following Cloud Frameworks for Python tutorial using the following command to install packages:
pip install --target lib --ignore-installed --system --find-links=file://$HOME/repo/google-endpoints-api-management/ --requirement=requirements.txt
(i also modified tutorial's requirements.txt to use google-endpoints-api-management==1.11.1)