### PR TITLE
Moving platform check for GAE_STANDARD before checking for GCE to avoid a network call

### DIFF
--- a/endpoints_management/control/wsgi.py
+++ b/endpoints_management/control/wsgi.py
@@ -72,14 +72,14 @@ def _get_platform():
         return report_request.ReportedPlatforms.DEVELOPMENT
     elif os.environ.get(u'KUBERNETES_SERVICE_HOST'):
         return report_request.ReportedPlatforms.GKE
+    elif server_software.startswith(u'Google App Engine'):
+        return report_request.ReportedPlatforms.GAE_STANDARD
     elif _running_on_gce():
         # We're either in GAE Flex or GCE
         if os.environ.get(u'GAE_MODULE_NAME'):
             return report_request.ReportedPlatforms.GAE_FLEX
         else:
             return report_request.ReportedPlatforms.GCE
-    elif server_software.startswith(u'Google App Engine'):
-        return report_request.ReportedPlatforms.GAE_STANDARD
 
     return report_request.ReportedPlatforms.UNKNOWN
 


### PR DESCRIPTION
Moving check for GAE_STANDARD before checking for GCE.
In GAE Standard environment occassional timeouts were seen, when accessing  _METADATA_SERVER_URL
With this change, GAE Standard environment does not have to pay penalty of a network call.